### PR TITLE
Fixed templates using old routes.

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -4,4 +4,4 @@ repos:
     hooks:
     -   id: pylint
         args: [--load-plugins, pylint_flask, -j4]
-        additional_dependencies: [pylint-flask, pytest]
+        additional_dependencies: [pylint-flask, pytest, flask, flask-login]

--- a/nlp4all/controllers/ProjectController.py
+++ b/nlp4all/controllers/ProjectController.py
@@ -12,6 +12,7 @@ from nlp4all.forms.analyses import AddBayesianAnalysisForm
 
 from nlp4all.helpers.analyses import (
     add_project,
+    get_user_projects,
 )  # @TODO: this add_project CLEARLY belongs on the model, not in helpers
 
 # from flask_mail import Message
@@ -19,6 +20,12 @@ from nlp4all.helpers.analyses import (
 
 class ProjectController:
     """Project controller"""
+
+    @classmethod
+    def home(cls):
+        """Home page"""
+        my_projects = get_user_projects(current_user)
+        return render_template("home.html", projects=my_projects)
 
     @classmethod
     def add_project(cls):

--- a/nlp4all/routes/project.py
+++ b/nlp4all/routes/project.py
@@ -11,3 +11,4 @@ ProjectRouter.route("/add_project", methods=["GET", "POST"])(
     login_required(ProjectController.add_project)
 )
 ProjectRouter.route("/project", methods=["GET", "POST"])(login_required(ProjectController.project))
+ProjectRouter.route("/home", methods=["GET", "POST"])(login_required(ProjectController.home))

--- a/nlp4all/routes/site.py
+++ b/nlp4all/routes/site.py
@@ -8,18 +8,4 @@ SiteRouter = Blueprint("site_controller", __name__)
 
 # AdminController.blueprint = AdminRouter
 SiteRouter.route('/', methods=["GET", "POST"])(SiteController.home)
-# SiteRouter.route('/home', methods=["GET", "POST"])(SiteController.manage_categories)
 SiteRouter.route("/about", methods=["GET", "POST"])(SiteController.about)
-
-
-# if not logged in redirect to projects, we should have an actual "home" page
-
-# @app.route("/")
-# @app.route("/home")
-# @app.route("/home/", methods=["GET", "POST"])
-
-# @login_required
-# def home():
-#     """Home page"""
-#     my_projects = get_user_projects(current_user)
-#     return render_template("home.html", projects=my_projects)

--- a/nlp4all/views/analysis.html
+++ b/nlp4all/views/analysis.html
@@ -9,14 +9,14 @@
                     <a class="nav-item nav-link" >Tweets</a>
                 </td>
                 <td>
-                    <a class="nav-item nav-link" href="{{ url_for('shared_analysis_view') }}?analysis={{ analysis.id }}">Label &amp; Word Statistics</a>
+                    <a class="nav-item nav-link" href="{{ url_for('analyses_controller.shared_analysis_view') }}?analysis={{ analysis.id }}">Label &amp; Word Statistics</a>
                 </td>
                 <td>
-                    <a class="nav-item nav-link" href="{{ url_for('annotations') }}?analysis_id={{ analysis.id }}">Annotations</a>
+                    <a class="nav-item nav-link" href="{{ url_for('analyses_controller.annotations') }}?analysis_id={{ analysis.id }}">Annotations</a>
                 </td>
                 {% if not analysis.shared %}
                 <td>
-                    <a class="nav-item nav-link" href="{{ url_for('robot') }}?robot={{ last_robot.id }}">Gå til seneste Robot</a>
+                    <a class="nav-item nav-link" href="{{ url_for('analyses_controller.robot') }}?robot={{ last_robot.id }}">Gå til seneste Robot</a>
                 </td>
                 {% endif %}
             </tr>

--- a/nlp4all/views/annotation_summary.html
+++ b/nlp4all/views/annotation_summary.html
@@ -2,7 +2,7 @@
 {% block content %}
 <h1>Annotation overview</h1>
 Here you can see how each tag has been used.
-<a class="nav-item nav-link" href="{{ url_for('analysis') }}?analysis={{ analysis.id }}">Back to analysis</a>
+<a class="nav-item nav-link" href="{{ url_for('analyses_controller.analysis') }}?analysis={{ analysis.id }}">Back to analysis</a>
 <div class="content-section">  
 
     <h4 id="headline">Now showing the tag: {{ tag }} </h4>

--- a/nlp4all/views/annotations.html
+++ b/nlp4all/views/annotations.html
@@ -8,17 +8,17 @@
         <table>
             <tr>
                 <td>
-                    <a class="nav-item nav-link" href="{{ url_for('analysis') }}?analysis={{ analysis.id }}">Tweets</a>
+                    <a class="nav-item nav-link" href="{{ url_for('analyses_controller.analysis') }}?analysis={{ analysis.id }}">Tweets</a>
                 </td>
                 <td>
-                    <a class="nav-item nav-link" href="{{ url_for('shared_analysis_view') }}?analysis={{ analysis.id }}">Label &amp; Word Statistics</a>
+                    <a class="nav-item nav-link" href="{{ url_for('analyses_controller.shared_analysis_view') }}?analysis={{ analysis.id }}">Label &amp; Word Statistics</a>
                 </td>
                 <td>
                     <a class="nav-item nav-link">Annotations</a>
                 </td>
                 {% if not analysis.shared %}
                 <td>
-                    <a class="nav-item nav-link" href="{{ url_for('robot') }}?robot={{ analysis.robots[-1].id }}">Gå til seneste Robot</a>
+                    <a class="nav-item nav-link" href="{{ url_for('analyses_controller.robot') }}?robot={{ analysis.robots[-1].id }}">Gå til seneste Robot</a>
                 </td>
                 {% endif %}
             </tr>
@@ -32,8 +32,8 @@
 
    
         <table>
-            <tr><td><span><a class="nav-item nav-link" href="{{ url_for('analysis') }}?analysis={{ analysis.id }}">Back to analysis</a></span></td></tr>
-            <tr><td><span><a class="nav-item nav-link" href="{{ url_for('annotation_summary', analysis_id= analysis.id ) }}">See annotation summary</a></span></td>
+            <tr><td><span><a class="nav-item nav-link" href="{{ url_for('analyses_controller.analysis') }}?analysis={{ analysis.id }}">Back to analysis</a></span></td></tr>
+            <tr><td><span><a class="nav-item nav-link" href="{{ url_for('analyses_controller.annotation_summary', analysis_id= analysis.id ) }}">See annotation summary</a></span></td>
             </tr>
         </table>
 

--- a/nlp4all/views/included_tweets.html
+++ b/nlp4all/views/included_tweets.html
@@ -3,7 +3,7 @@
 {% block content %}
 <h1>Tweets</h1>
 <div>
-    <p>Back to the <a href="{{ url_for('matrix', matrix_id=matrix.id) }}">confusion matrix</a></p>
+    <p>Back to the <a href="{{ url_for('analyses_controller.matrix', matrix_id=matrix.id) }}">confusion matrix</a></p>
 </div>
 
 <div class="tab-pane fade" id="profile" role="tabpanel" aria-labelledby="profile-tab">

--- a/nlp4all/views/layout.html
+++ b/nlp4all/views/layout.html
@@ -26,9 +26,9 @@
             <!-- Navbar Right Side -->
             <div class="navbar-nav">
               {% if current_user.is_authenticated %}
-              <a class="nav-item nav-link" href="{{ url_for('home') }}">My Projects</a>
-                <a class="nav-item nav-link" href="{{ url_for('my_matrices') }}">My Matrices</a>
-                <a class="nav-item nav-link" href="{{ url_for('account') }}">Account</a>
+              <a class="nav-item nav-link" href="{{ url_for('project_controller.home') }}">My Projects</a>
+                <a class="nav-item nav-link" href="{{ url_for('analyses_controller.my_matrices') }}">My Matrices</a>
+                <a class="nav-item nav-link" href="{{ url_for('user_controller.account') }}">Account</a>
                 <a class="nav-item nav-link" href="{{ url_for('user_controller.logout') }}">Logout</a>
               {% else %}
                 <a class="nav-item nav-link" href="{{ url_for('user_controller.login') }}">Login</a>

--- a/nlp4all/views/matrix.html
+++ b/nlp4all/views/matrix.html
@@ -6,7 +6,7 @@
     
     <h1> Confusion Matrix </h1>
     <br>
-    <p><a href="{{ url_for('matrix_overview') }}">See overview over all matrices.</a></p>
+    <p><a href="{{ url_for('analyses_controller.matrix_overview') }}">See overview over all matrices.</a></p>
     
     
     <ul class="nav nav-tabs" id="myTab" role="tablist">

--- a/nlp4all/views/matrix_summary.html
+++ b/nlp4all/views/matrix_summary.html
@@ -8,7 +8,7 @@
 {% for m in matrices %}
 <div class="content-section">
 
-<b><a href= {{ url_for('matrix', matrix_id=m.id) }}>Matrix {{ m.id }}</a></b>
+<b><a href= {{ url_for('analyses_controller.matrix', matrix_id=m.id) }}>Matrix {{ m.id }}</a></b>
 </br>
 <tr><td><i><b>Categories: </b></td><td> 
     {% for c in m.categories %}

--- a/nlp4all/views/matrix_table_base.html
+++ b/nlp4all/views/matrix_table_base.html
@@ -56,7 +56,7 @@
 
     </div>
     </div>
-    <p><a href="{{ url_for('matrix_overview') }}">Go back to all matrices</a></p>
+    <p><a href="{{ url_for('analyses_controller.matrix_overview') }}">Go back to all matrices</a></p>
 
     
 

--- a/nlp4all/views/matrix_template.html
+++ b/nlp4all/views/matrix_template.html
@@ -21,7 +21,7 @@
             
             <tr>
                 {% for i in l %}
-                <td class='{{ i[1] }}'><a class='link' href="{{ url_for('matrix_tweets', matrix_id=matrix.id) }}?cm={{ i[1] }}">{{ i[0] }}</a></td>
+                <td class='{{ i[1] }}'><a class='link' href="{{ url_for('analyses_controller.matrix_tweets', matrix_id=matrix.id) }}?cm={{ i[1] }}">{{ i[0] }}</a></td>
                 {% endfor %}
             </tr>
             
@@ -74,8 +74,8 @@
             <p>Accuracy: {{ matrix.data.accuracy }} </p>
             
 
-            <p>Tweets in matrix: <a href="{{ url_for('included_tweets', matrix_id=matrix.id) }}">{{ matrix.data['nr_incl_tweets'] }}</a>  / {{ matrix.data['nr_test_tweets'] }}</p>
-            <p>Excluded tweets: <a href="{{ url_for('excluded_tweets', matrix_id=matrix.id) }}">{{ matrix.data['nr_excl_tweets'] }}</a>  / {{ matrix.data['nr_test_tweets'] }}</p>
+            <p>Tweets in matrix: <a href="{{ url_for('analyses_controller.included_tweets', matrix_id=matrix.id) }}">{{ matrix.data['nr_incl_tweets'] }}</a>  / {{ matrix.data['nr_test_tweets'] }}</p>
+            <p>Excluded tweets: <a href="{{ url_for('analyses_controller.excluded_tweets', matrix_id=matrix.id) }}">{{ matrix.data['nr_excl_tweets'] }}</a>  / {{ matrix.data['nr_test_tweets'] }}</p>
             </ul>
         </div>
         <div class="content-section">
@@ -127,7 +127,7 @@ $(document).ready( function () {
 
         for(var i=0; i<returnedData[0].length; i++){
                         for(var j=0; j<returnedData[0][i].length; j++){
-                                span = $('<span class="'+returnedData[0][i][j][1]+'" title="'+returnedData[0][i][j][1]+'" value='+returnedData[0][i][j][1]+'><a class='link' href="{{ url_for('matrix_tweets', matrix_id=matrix.id) }}?cm={{ '+returnedData[0][i][j][1]+' }}">{{ '+returnedData[0][i][j][0]+' }}</a>'+'</span>')
+                                span = $('<span class="'+returnedData[0][i][j][1]+'" title="'+returnedData[0][i][j][1]+'" value='+returnedData[0][i][j][1]+'><a class='link' href="{{ url_for('analyses_controller.matrix_tweets', matrix_id=matrix.id) }}?cm={{ '+returnedData[0][i][j][1]+' }}">{{ '+returnedData[0][i][j][0]+' }}</a>'+'</span>')
                                 console.log(span)
                                 span.css("margin-left",  '.05rem');
                                 span.css("background-color", 'hsl('+returnedData[0][i][j][3][0]+', '+returnedData[0][i][j][3][1]+'% , '+returnedData[0][i][j][3][2]+'%)');

--- a/nlp4all/views/matrix_template_copy.html
+++ b/nlp4all/views/matrix_template_copy.html
@@ -30,8 +30,8 @@
         <p>Trained on {{ matrix.data.nr_train_tweets }} tweets.</p>
         <p>Current certainty threshold: {{ matrix.threshold }}</p>
         <p>Accuracy: {{ matrix.data.accuracy }} </p>
-        <p>Tweets in matrix: <a href="{{ url_for('included_tweets', matrix_id=matrix.id) }}">{{ matrix.data['nr_incl_tweets'] }}</a>  / {{ matrix.data['nr_test_tweets'] }}</p>
-        <p>Excluded tweets: <a href="{{ url_for('excluded_tweets', matrix_id=matrix.id) }}">{{ matrix.data['nr_excl_tweets'] }}</a>  / {{ matrix.data['nr_test_tweets'] }}</p>
+        <p>Tweets in matrix: <a href="{{ url_for('analyses_controller.included_tweets', matrix_id=matrix.id) }}">{{ matrix.data['nr_incl_tweets'] }}</a>  / {{ matrix.data['nr_test_tweets'] }}</p>
+        <p>Excluded tweets: <a href="{{ url_for('analyses_controller.excluded_tweets', matrix_id=matrix.id) }}">{{ matrix.data['nr_excl_tweets'] }}</a>  / {{ matrix.data['nr_test_tweets'] }}</p>
         </ul>
     
 

--- a/nlp4all/views/matrix_tweets.html
+++ b/nlp4all/views/matrix_tweets.html
@@ -3,7 +3,7 @@
 {% block content %}
 <h1>{{ title }}</h1>
 <div>
-    <p>Back to the <a href="{{ url_for('matrix', matrix_id=matrix.id) }}">confusion matrix</a></p>
+    <p>Back to the <a href="{{ url_for('analyses_controller.matrix', matrix_id=matrix.id) }}">confusion matrix</a></p>
 </div>
 
 <div class="content-section">

--- a/nlp4all/views/my_matrices.html
+++ b/nlp4all/views/my_matrices.html
@@ -12,7 +12,7 @@
     
     <div class="col-md-8"> 
       <h3>My Matrices</h3>
-    <p><a href="{{ url_for('matrix_overview') }}">See your matrix overview</a></p>
+    <p><a href="{{ url_for('analyses_controller.matrix_overview') }}">See your matrix overview</a></p>
   <div>
     {% set matrices = matrices %}
     {% include "matrix_summary.html" %}

--- a/nlp4all/views/post.html
+++ b/nlp4all/views/post.html
@@ -4,11 +4,11 @@
     <img class="rounded-circle article-img" src="{{ url_for('static', filename='profile_pics/' + post.author.image_file) }}">
     <div class="media-body">
       <div class="article-metadata">
-        <a class="mr-2" href="{{ url_for('user_posts', username=post.author.username) }}">{{ post.author.username }}</a>
+        <a class="mr-2" href="{{ url_for('user_controller.user_posts', username=post.author.username) }}">{{ post.author.username }}</a>
         <small class="text-muted">{{ post.date_posted.strftime('%Y-%m-%d') }}</small>
         {% if post.author == current_user %}
           <div>
-            <a class="btn btn-secondary btn-sm mt-1 mb-1" href="{{ url_for('update_post', post_id=post.id) }}">Update</a>
+            <a class="btn btn-secondary btn-sm mt-1 mb-1" href="{{ url_for('user_controller.update_post', post_id=post.id) }}">Update</a>
             <button type="button" class="btn btn-danger btn-sm m-1" data-toggle="modal" data-target="#deleteModal">Delete</button>
           </div>
         {% endif %}
@@ -29,7 +29,7 @@
         </div>
         <div class="modal-footer">
           <button type="button" class="btn btn-secondary" data-dismiss="modal">Close</button>
-          <form action="{{ url_for('delete_post', post_id=post.id) }}" method="POST">
+          <form action="{{ url_for('user_controller.delete_post', post_id=post.id) }}" method="POST">
             <input class="btn btn-danger" type="submit" value="Delete">
           </form>
         </div>

--- a/nlp4all/views/project.html
+++ b/nlp4all/views/project.html
@@ -10,12 +10,12 @@
 {% for a in analyses %}
 
 <div class="content-section">
-<a class="nav-item nav-link" href="{{ url_for('analysis') }}?analysis={{a.id}}">{{a.name}}</a>
+<a class="nav-item nav-link" href="{{ url_for('analyses_controller.analysis') }}?analysis={{a.id}}">{{a.name}}</a>
 </div>
 {% endfor %}
 </div>
 {% for p in projects %}
-<a class="nav-item nav-link" href="{{ url_for('project') }}?project={{ p.id }}">p.name</a>
+<a class="nav-item nav-link" href="{{ url_for('project_controller.project') }}?project={{ p.id }}">p.name</a>
 {% endfor %}
 </div>
 

--- a/nlp4all/views/projects.html
+++ b/nlp4all/views/projects.html
@@ -9,7 +9,7 @@
   <h1>My Projects</h1>
     <div class="content-section col-md-8">
 {% for p in projects %}
-<a class="nav-item nav-link" href="{{ url_for('project') }}?project={{ p.id }}">{{ p.name }}</a>
+<a class="nav-item nav-link" href="{{ url_for('project_controller.project') }}?project={{ p.id }}">{{ p.name }}</a>
 <p>{{ p.description }} </p>
 {% endfor %}
 </div>

--- a/nlp4all/views/register_imc.html
+++ b/nlp4all/views/register_imc.html
@@ -27,7 +27,7 @@
     </div>
     <div class="border-top pt-3">
         <small class="text-muted">
-            Already Have An Account? <a class="ml-2" href="{{ url_for('login') }}">Sign In</a>
+            Already Have An Account? <a class="ml-2" href="{{ url_for('user_controller.login') }}">Sign In</a>
         </small>
     </div>
 {% endblock content %}

--- a/nlp4all/views/robot.html
+++ b/nlp4all/views/robot.html
@@ -4,12 +4,12 @@
 <table class="table"> 
     <tr>
 {%if r.parent != None %}
-<td><a href="{{ url_for('robot') }}?robot={{ r.parent}}">Last results</a></td>
+<td><a href="{{ url_for('analyses_controller.robot') }}?robot={{ r.parent}}">Last results</a></td>
 {% endif %}
-<td><a href="{{ url_for('analysis') }}?analysis={{ r.analysis}}">Tweets</a></td>
-<td><a href="{{ url_for('robot_summary') }}?analysis={{ r.analysis}}">Analyses Overview</a></td>
+<td><a href="{{ url_for('analyses_controller.analysis') }}?analysis={{ r.analysis}}">Tweets</a></td>
+<td><a href="{{ url_for('ranalyses_controller.obot_summary') }}?analysis={{ r.analysis}}">Analyses Overview</a></td>
 {%if r.child != None %}
-<td><a href="{{ url_for('robot') }}?robot={{ r.child}}">Improve your analysis >>>>> </a></td>
+<td><a href="{{ url_for('analyses_controller.robot') }}?robot={{ r.child}}">Improve your analysis >>>>> </a></td>
 {% endif %}
 </table>
 <!-- <h5>{{ r.name }} {% if r.retired %} (Old) {% endif %}</h5> -->

--- a/nlp4all/views/robot_summary.html
+++ b/nlp4all/views/robot_summary.html
@@ -4,7 +4,7 @@
     <h1>Oversigt over jeres robotter</h1>
 {% for r in robots %}
 <div class="content-section">
-<a href= {{ url_for('robot') }}?robot={{r.id}}>Se Robotten</a>
+<a href= {{ url_for('analyses_controller.robot') }}?robot={{r.id}}>Se Robotten</a>
 <table class="table">
 <tr><td>Accuracy: </td><td>{{ r.accuracy.accuracy }} </td></tr>
 <tr><td>Tweets ramt: </td><td>{{ r.accuracy.tweets_targeted }} </td></tr>

--- a/nlp4all/views/shared_analysis_view.html
+++ b/nlp4all/views/shared_analysis_view.html
@@ -4,17 +4,17 @@
     <table>
         <tr>
                 <td>
-                    <a class="nav-item nav-link" href="{{ url_for('analysis') }}?analysis={{ analysis.id }}">Tweets</a>
+                    <a class="nav-item nav-link" href="{{ url_for('analyses_controller.analysis') }}?analysis={{ analysis.id }}">Tweets</a>
                 </td>
                 <td>
                     <a class="nav-item nav-link">Label &amp; Word Statistics</a>
                 </td>
                 <td>
-                    <a class="nav-item nav-link" href="{{ url_for('annotations') }}?analysis_id={{ analysis.id }}">Annotations</a>
+                    <a class="nav-item nav-link" href="{{ url_for('analyses_controller.annotations') }}?analysis_id={{ analysis.id }}">Annotations</a>
                 </td>
                 {% if not analysis.shared %}
                 <td>
-                    <a class="nav-item nav-link" href="{{ url_for('robot') }}?robot={{ analysis.robots[-1].id }}">Gå til seneste Robot</a>
+                    <a class="nav-item nav-link" href="{{ url_for('analyses_controller.robot') }}?robot={{ analysis.robots[-1].id }}">Gå til seneste Robot</a>
                 </td>
                 {% endif %}
         </tr>

--- a/nlp4all/views/user_posts.html
+++ b/nlp4all/views/user_posts.html
@@ -6,10 +6,10 @@
           <img class="rounded-circle article-img" src="{{ url_for('static', filename='profile_pics/' + post.author.image_file) }}">
           <div class="media-body">
             <div class="article-metadata">
-              <a class="mr-2" href="{{ url_for('user_posts', username=post.author.username) }}">{{ post.author.username }}</a>
+              <a class="mr-2" href="{{ url_for('user_controller.user_posts', username=post.author.username) }}">{{ post.author.username }}</a>
               <small class="text-muted">{{ post.date_posted.strftime('%Y-%m-%d') }}</small>
             </div>
-            <h2><a class="article-title" href="{{ url_for('post', post_id=post.id) }}">{{ post.title }}</a></h2>
+            <h2><a class="article-title" href="{{ url_for('user_controller.post', post_id=post.id) }}">{{ post.title }}</a></h2>
             <p class="article-content">{{ post.content }}</p>
           </div>
         </article>
@@ -17,9 +17,9 @@
     {% for page_num in posts.iter_pages(left_edge=1, right_edge=1, left_current=1, right_current=2) %}
       {% if page_num %}
         {% if posts.page == page_num %}
-          <a class="btn btn-info mb-4" href="{{ url_for('user_posts', username=user.username, page=page_num) }}">{{ page_num }}</a>
+          <a class="btn btn-info mb-4" href="{{ url_for('user_controller.user_posts', username=user.username, page=page_num) }}">{{ page_num }}</a>
         {% else %}
-          <a class="btn btn-outline-info mb-4" href="{{ url_for('user_posts', username=user.username, page=page_num) }}">{{ page_num }}</a>
+          <a class="btn btn-outline-info mb-4" href="{{ url_for('user_controller.user_posts', username=user.username, page=page_num) }}">{{ page_num }}</a>
         {% endif %}
       {% else %}
         ...


### PR DESCRIPTION
After restructuring, I'd left the templates as is because we need to organize them and remove unused ones...

unfortunately, this caused a problem with the site if it tried to load a template with a `url_for` using the old routes...this is fixed now.