### PR TITLE
Fixed previously required dependency `py` that had a vulnerability.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -48,7 +48,6 @@ pip-upgrader==1.4.15
 platformdirs==2.5.2
 pluggy==1.0.0
 pre-commit==2.20.0
-py==1.11.0
 pycparser==2.21
 PyJWT==2.5.0
 PySocks==1.7.1


### PR DESCRIPTION
fixes https://github.com/NLP4ALL/nlp4all/security/dependabot/1 by removing the `py` dependency from `requirements.txt` we use `pytest-7.2.0` which doesn't need `py` and it should have been in `requirements-dev.txt` anyway.